### PR TITLE
Fixed config loading for Realism v1.2.0

### DIFF
--- a/Plugin/Plugin.cs
+++ b/Plugin/Plugin.cs
@@ -88,8 +88,7 @@ namespace SkillsExtended
             if (Chainloader.PluginInfos.ContainsKey("RealismMod"))
             {
                 var jsonString = RequestHandler.GetJson("/RealismMod/GetInfo");
-                var str = JsonConvert.DeserializeObject<string>(jsonString);
-                RealismConfig = JsonConvert.DeserializeObject<RealismConfig>(str);
+                RealismConfig = JsonConvert.DeserializeObject<RealismConfig>(jsonString);
                 Log.LogInfo("Realism mod detected");
             }
 


### PR DESCRIPTION
Realism no longer double serializes the config request in v1.2.0 (see https://github.com/space-commits/SPT-Realism-Mod-Server/pull/42) this broke Skills Extended.

This PR fixes the reported incompatibility.