### PR TITLE
Fix System.NullReferenceException @ SkillClass.OnTrigger()

### DIFF
--- a/Plugin/Patches/SkillsPatches.cs
+++ b/Plugin/Patches/SkillsPatches.cs
@@ -86,7 +86,10 @@ internal class SkillManagerConstructorPatch : ModulePatch
         
         AccessTools.Field(typeof(SkillClass), "Locked").SetValue(__instance.FieldMedicine,
             !Plugin.SkillData.MedicalSkills.EnableFieldMedicine);
-    }
+
+        //BonusController is called in SkillClass.OnTrigger and must not be null, otherwise it will trigger System.NullReferenceException.
+        __instance.BonusController = new();
+	}
 }
 
 internal class SkillClassCtorPatch : ModulePatch


### PR DESCRIPTION
Possible fix for inconsistent System.NullReferenceException throws from SkillClass.OnTrigger().