### PR TITLE
Fixed GroundZero 21+ not registered in LocationDoorIdLevels 

### DIFF
--- a/Plugin/LockPicking/LpHelpers.cs
+++ b/Plugin/LockPicking/LpHelpers.cs
@@ -29,6 +29,7 @@ internal static class LpHelpers
         {"Lighthouse", Plugin.SkillData.LockPicking.DoorPickLevels.Lighthouse},
         {"TarkovStreets", Plugin.SkillData.LockPicking.DoorPickLevels.Streets},
         {"Sandbox", Plugin.SkillData.LockPicking.DoorPickLevels.GroundZero},
+        {"Sandbox_high", Plugin.SkillData.LockPicking.DoorPickLevels.GroundZero},
     };
     
     /// <summary>

--- a/Plugin/Plugin.cs
+++ b/Plugin/Plugin.cs
@@ -23,7 +23,7 @@ using UnityEngine.UI;
 
 namespace SkillsExtended;
 
-[BepInPlugin("com.dirtbikercj.SkillsExtended", "Skills Extended", "1.3.1")]
+[BepInPlugin("com.dirtbikercj.SkillsExtended", "Skills Extended", "1.3.2")]
 [BepInDependency("com.IcyClawz.CustomInteractions")]
 [BepInDependency("com.dirtbikercj.QuestsExtended")]
 public class Plugin : BaseUnityPlugin

--- a/Plugin/Skills Extended.csproj
+++ b/Plugin/Skills Extended.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
     <AssemblyName>SkillsExtended</AssemblyName>
     <Description>New Skills!</Description>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
 	<Configurations>Debug;Release;BETA</Configurations>

--- a/Server/KeyDoorIds.txt
+++ b/Server/KeyDoorIds.txt
@@ -266,6 +266,7 @@ Door ID: Lighthouse_WaterStation_00044 KeyID: 61aa5aed32a4743c3453d319 Key Name:
 Door ID: Lighthouse_WaterStation_00019 KeyID: 61aa81fcb225ac1ead7957c3 Key Name: Rogue USEC workshop key
 Door ID: Lighthouse_WaterStation_00017 KeyID: 61a64492ba05ef10d62adcc1 Key Name: Rogue USEC stash key
 Door ID: trunk_Lighthouse_Extension_00005 KeyID: 5448ba0b4bdc2d02308b456c Key Name: Factory emergency exit key
+Door ID: Lighthouse_SummerHotel_00035 KeyID: 66265d7be65f224b2e17c6aa Key Name: USEC cottage room key
 
 STREETS:
 

--- a/Server/package.json
+++ b/Server/package.json
@@ -26,7 +26,8 @@
         "os": "^0.1",
         "tsyringe": "4.8.0",
         "typescript": "5.2.2",
-        "winston": "3.11.0"
+        "winston": "3.11.0",
+        "bestzip": "^2.2.1"
     },
     "dependencies": {
     }

--- a/Server/package.json
+++ b/Server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "Skills Extended",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "main": "src/mod.js",
     "license": "CC BY-NC-ND 4.0",
     "author": "dirtbikercj",


### PR DESCRIPTION
This should fix #25 as the doors where configured for GroundZero but the high level variant of it was never registered as seperate map in the LocationDoorIdLevels.

I also added the USEC cottage room key to the helper list, and added bestzip to the dev dependencies