### PR TITLE
Fix build for Linux Servers

### DIFF
--- a/Server/Core/ConfigController.cs
+++ b/Server/Core/ConfigController.cs
@@ -24,7 +24,7 @@ public class ConfigController(
 
     public async Task SaveSkillsConfig()
     {
-        var path = Path.Combine(SeModMetadata.ResourcesDirectory, "configs", "SkillsConfig.json");
+        var path = Path.Combine(SeModMetadata.ResourcesDirectory, "Configs", "SkillsConfig.json");
         
         var text = jsonUtil.Serialize(SkillsConfig, true);
         await fileUtil.WriteFileAsync(path, text!);
@@ -32,7 +32,7 @@ public class ConfigController(
     
     private async Task LoadSkillsConfig()
     {
-        var path = Path.Combine(SeModMetadata.ResourcesDirectory, "configs", "SkillsConfig.json");
+        var path = Path.Combine(SeModMetadata.ResourcesDirectory, "Configs", "SkillsConfig.json");
         
         var text = await fileUtil.ReadFileAsync(path);
         SkillsConfig = jsonUtil.Deserialize<SkillsConfig>(text)!;

--- a/Server/Properties/launchSettings.json
+++ b/Server/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Server": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:56403;http://localhost:56404"
+    }
+  }
+}


### PR DESCRIPTION
When adding this mod into a Linux server, you will most likely get this error

```
Fatal error. System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
at System.SpanHelpers.Memmove(Byte ByRef, Byte ByRef, UIntPtr)
at System.Span`1[[System.Byte, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].CopyTo(System.Span`1<Byte>)
at System.Reflection.Internal.ReadOnlyUnmanagedMemoryStream.Read(System.Span`1<Byte>)
at System.IO.Stream.ReadAtLeastCore(System.Span`1<Byte>, Int32, Boolean)
at System.IO.BinaryReader.InternalRead(System.Span`1<Byte>)
at System.IO.BinaryReader.ReadUInt16()
at System.Reflection.PortableExecutable.PEHeaders.SkipDosHeader(System.Reflection.PortableExecutable.PEBinaryReader ByRef, Boolean ByRef)
at System.Reflection.PortableExecutable.PEHeaders..ctor(System.IO.Stream, Int32, Boolean)
at System.Reflection.PortableExecutable.PEReader.InitializePEHeaders()
at System.Reflection.PortableExecutable.PEReader.ReadDebugDirectory()
at System.Reflection.PortableExecutable.PEReader.TryOpenAssociatedPortablePdb(System.String, System.Func`2<System.String,System.IO.Stream>, System.Reflection.Metadata.MetadataReaderProvider ByRef, System.String ByRef)
at System.Diagnostics.StackTraceSymbols.TryOpenReaderFromAssemblyFile(System.String, IntPtr, Int32, Boolean)
at System.Diagnostics.StackTraceSymbols.TryGetReader(System.Reflection.Assembly, System.String, IntPtr, Int32, Boolean, IntPtr, Int32)
at System.Diagnostics.StackTraceSymbols.GetSourceLineInfo(System.Reflection.Assembly, System.String, IntPtr, Int32, Boolean, IntPtr, Int32, Int32, Int32, System.String ByRef, Int32 ByRef, Int32 ByRef)
at System.Diagnostics.StackFrameHelper.InitializeSourceInfo(Int32, Boolean, System.Exception)
at System.Diagnostics.StackTrace.CaptureStackTrace(Int32, Boolean, System.Exception)
at System.Exception.get_StackTrace()
at SPTarkov.Server.Core.Utils.Logger.Handlers.BaseLogHandler.FormatMessage(System.String, SPTarkov.Server.Core.Utils.Logger.SptLogMessage, SPTarkov.Server.Core.Utils.Logger.BaseSptLoggerReference)
at SPTarkov.Server.Core.Utils.Logger.Handlers.FileLogHandler.Log(SPTarkov.Server.Core.Utils.Logger.SptLogMessage, SPTarkov.Server.Core.Utils.Logger.BaseSptLoggerReference)
at SPTarkov.Server.Core.Utils.Logger.SptLoggerQueueManager+<>c__DisplayClass12_0.<LogMessage>b__0(SPTarkov.Server.Core.Utils.Logger.BaseSptLoggerReference)
at System.Collections.Generic.List`1[[System.__Canon, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].ForEach(System.Action`1<System.__Canon>)
at SPTarkov.Server.Core.Utils.Logger.SptLoggerQueueManager.LogMessage(SPTarkov.Server.Core.Utils.Logger.SptLogMessage)
at SPTarkov.Server.Core.Utils.Logger.SptLoggerQueueManager.LoggerWorkerThread()
```

# Why does it happen?
Linux servers directives are case sensitive, so just by changing the route with the correct letter casing, will fix this error.