### PR TITLE
Alternative lock picking

### DIFF
--- a/Common/Config/Skills/LockpickingData.cs
+++ b/Common/Config/Skills/LockpickingData.cs
@@ -5,6 +5,9 @@ namespace SkillsExtended.Config.Skills;
 public class LockPickingData
 {
     public bool Enabled { get; set; }
+    public bool UseAlternativeLockpicking { get; set; }
+    public float BaseLockpickDurationSeconds { get; set; }
+    public float BaseFailureChance { get; set; }
     public float PickStrengthBase { get; set; }
     public float PickStrengthPerLevel { get; set; }
     public float SweetSpotRangeBase { get; set; }

--- a/Plugin/Skills/LockPicking/Actions/Actions.cs
+++ b/Plugin/Skills/LockPicking/Actions/Actions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using EFT;
 using EFT.Interactive;
 using SkillsExtended.Helpers;
+using SkillsExtended.Skills.LockPicking.Alternative;
 
 namespace SkillsExtended.Skills.LockPicking.Actions;
 
@@ -10,7 +11,7 @@ public static class LockPickActions
 {
     public static void PickLock(WorldInteractiveObject interactiveObject, GamePlayerOwner owner)
     {
-        if (LockPickingHelpers.LockPickingGame.activeSelf)
+        if (LockPickingHelpers.LockPickingGame.activeSelf || AlternativeLockpick.IsInProgress)
         {
             return;
         }
@@ -52,18 +53,24 @@ public static class LockPickActions
                 return;
             }
 
+            LockPickActionHandler handler = new()
+            {
+                Owner = owner,
+                InteractiveObject = interactiveObject,
+            };
+            
+            if (SkillsExtendedPlugin.SkillData.LockPicking.UseAlternativeLockpicking)
+            {
+                AlternativeLockpick.StartPick(owner, interactiveObject, handler, level);
+                return;
+            }
+            
             if (!LockPickingHelpers.DoorSweetSpotRanges.TryGetValue(interactiveObject.Id, out var range))
             {
                 var error = $"ERROR: Door {interactiveObject.Id} on map {owner.Player.Location} sweet spot range not initialized, screenshot and report this error to the developer.";
                 ShowErrorNotification(error);
                 return;
             }
-            
-            LockPickActionHandler handler = new()
-            {
-                Owner = owner,
-                InteractiveObject = interactiveObject,
-            };
             
             LockPickingHelpers.LockPickingGame.SetActive(true);
             

--- a/Plugin/Skills/LockPicking/Actions/Actions.cs
+++ b/Plugin/Skills/LockPicking/Actions/Actions.cs
@@ -61,6 +61,11 @@ public static class LockPickActions
             
             if (SkillsExtendedPlugin.SkillData.LockPicking.UseAlternativeLockpicking)
             {
+                if (AlternativeLockpick.IsDoorLockedOut(interactiveObject.Id))
+                {
+                    return;
+                }
+                
                 AlternativeLockpick.StartPick(owner, interactiveObject, handler, level);
                 return;
             }

--- a/Plugin/Skills/LockPicking/Alternative/AlternativeLockpick.cs
+++ b/Plugin/Skills/LockPicking/Alternative/AlternativeLockpick.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using EFT;
 using EFT.Interactive;
 using SkillsExtended.Skills.LockPicking.Actions;
@@ -12,6 +13,8 @@ public sealed class AlternativeLockpick: MonoBehaviour
 {
     private static AlternativeLockpick _instance;
 
+    private static readonly Dictionary<string, float> _doorLockoutUntil = new();
+    
     private AudioSource _lockpickingSfx;
     private AudioSource _failureSfx;
     
@@ -62,10 +65,10 @@ public sealed class AlternativeLockpick: MonoBehaviour
             return;
         }
 
-        _instance.StartCoroutine(_instance.PickRoutine(owner, handler, doorLevel));
+        _instance.StartCoroutine(_instance.PickRoutine(owner, handler, door.Id, doorLevel));
     }
 
-    private IEnumerator PickRoutine(GamePlayerOwner owner, LockPickActionHandler handler, int doorLevel)
+    private IEnumerator PickRoutine(GamePlayerOwner owner, LockPickActionHandler handler, string doorId, int doorLevel)
     {
         _inProgress = true;
 
@@ -126,6 +129,11 @@ public sealed class AlternativeLockpick: MonoBehaviour
                 bool success = Random.value >= failChance;
                 result = success;
                 handler.PickLockAction(success);
+                
+                if (success)
+                {
+                    SetDoorLockout(doorId, 1f);
+                }
             }
         }
         finally
@@ -205,5 +213,22 @@ public sealed class AlternativeLockpick: MonoBehaviour
         return Input.GetMouseButtonDown(0) 
                || Input.GetMouseButtonDown(1) 
                || Input.GetKey(KeyCode.Escape); 
+    }
+    
+    public static bool IsDoorLockedOut(string doorId)
+    {
+        if (string.IsNullOrEmpty(doorId)) return false;
+        if (!_doorLockoutUntil.TryGetValue(doorId, out var until)) return false;
+
+        if (Time.unscaledTime < until) return true;
+
+        _doorLockoutUntil.Remove(doorId);
+        return false;
+    }
+
+    private static void SetDoorLockout(string doorId, float seconds)
+    {
+        if (string.IsNullOrEmpty(doorId)) return;
+        _doorLockoutUntil[doorId] = Time.unscaledTime + seconds;
     }
 }

--- a/Plugin/Skills/LockPicking/Alternative/AlternativeLockpick.cs
+++ b/Plugin/Skills/LockPicking/Alternative/AlternativeLockpick.cs
@@ -1,0 +1,209 @@
+﻿using System.Collections;
+using EFT;
+using EFT.Interactive;
+using SkillsExtended.Skills.LockPicking.Actions;
+using SkillsExtended.Utils;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+namespace SkillsExtended.Skills.LockPicking.Alternative;
+
+public sealed class AlternativeLockpick: MonoBehaviour
+{
+    private static AlternativeLockpick _instance;
+
+    private AudioSource _lockpickingSfx;
+    private AudioSource _failureSfx;
+    
+    private bool _inProgress;
+    public static bool IsInProgress => _instance != null && _instance._inProgress;
+
+    private AlternativeLockpickUI _ui;
+
+    public static void EnsureInstance()
+    {
+        if (_instance != null)
+        {
+            return;
+        }
+
+        var go = new GameObject("SkillsExtended.AlternativeLockpickController");
+        DontDestroyOnLoad(go);
+
+        _instance = go.AddComponent<AlternativeLockpick>();
+        _instance._ui = AlternativeLockpickUI.EnsureInstance();
+        
+        _instance._lockpickingSfx = go.AddComponent<AudioSource>();
+        _instance._lockpickingSfx.playOnAwake = false;
+        _instance._lockpickingSfx.loop = true;
+        _instance._lockpickingSfx.spatialBlend = 0f;
+        _instance._lockpickingSfx.ignoreListenerPause = true;
+        _instance._lockpickingSfx.ignoreListenerVolume = false;
+
+        _instance._failureSfx = go.AddComponent<AudioSource>();
+        _instance._failureSfx.playOnAwake = false;
+        _instance._failureSfx.loop = false;
+        _instance._failureSfx.spatialBlend = 0f;
+        _instance._lockpickingSfx.ignoreListenerPause = true;
+        _instance._failureSfx.ignoreListenerVolume = false;
+    }
+
+    public static void StartPick(GamePlayerOwner owner, WorldInteractiveObject door, LockPickActionHandler handler, int doorLevel)
+    {
+        EnsureInstance();
+
+        if (_instance._inProgress)
+        {
+            return;
+        }
+
+        if (owner == null || owner.Player == null || door == null || handler == null)
+        {
+            return;
+        }
+
+        _instance.StartCoroutine(_instance.PickRoutine(owner, handler, doorLevel));
+    }
+
+    private IEnumerator PickRoutine(GamePlayerOwner owner, LockPickActionHandler handler, int doorLevel)
+    {
+        _inProgress = true;
+
+        var player = owner?.Player;
+        
+        if (player == null || !player.IsYourPlayer)
+        {
+            _ui.Hide();
+            yield break;
+        }
+        
+        float durationSec = CalculateDurationSeconds(doorLevel);
+        float failChance = CalculateFailChance(doorLevel);
+
+        bool? result = null;
+
+        _ui.Show(durationSec);
+        
+        var lp = LockPickingHelpers.LockPickingGame?.GetComponent<LockPickingGame>();
+
+        var stuck = lp?.clickSound;
+        var reset = lp?.resetSound;
+
+        if (stuck != null)
+        {
+            _lockpickingSfx.clip = stuck;
+            _lockpickingSfx.Play();
+        }
+
+        try
+        {
+            player.MovementContext.ToggleBlockInputPlayerRotation(true);
+            player.CurrentManagedState.ChangePose(-1f);
+            GamePlayerOwner.IgnoreInputWithKeepResetLook = true;
+            GamePlayerOwner.IgnoreInputInNPCDialog = true;
+
+            float elapsed = 0f;
+
+            while (elapsed < durationSec)
+            {
+                if (ShouldClose())
+                {
+                    result = false;
+                    handler.PickLockAction(false);
+                    break;
+                }
+
+                elapsed += Time.unscaledDeltaTime;
+
+                _ui.SetProgress(elapsed / durationSec);
+                _ui.SetSeconds(Mathf.Max(0f, durationSec - elapsed));
+
+                yield return null;
+            }
+            
+            if (!result.HasValue)
+            {
+                bool success = Random.value >= failChance;
+                result = success;
+                handler.PickLockAction(success);
+            }
+        }
+        finally
+        {
+            if (_lockpickingSfx.isPlaying)
+            {
+                _lockpickingSfx.Stop();
+                _lockpickingSfx.clip = null;
+            }
+            
+            player.MovementContext.ToggleBlockInputPlayerRotation(false);
+            player.CurrentManagedState.ChangePose(1f);
+            GamePlayerOwner.IgnoreInputWithKeepResetLook = false;
+            GamePlayerOwner.IgnoreInputInNPCDialog = false;
+
+            _inProgress = false;
+
+            if (result.HasValue)
+            {
+                if (!result.Value && reset != null)
+                {
+                    _failureSfx.PlayOneShot(reset);
+                }
+                
+                _ui.ShowResult(result.Value);
+            }
+            else
+            {
+                _ui.Hide();
+            }
+        }
+    }
+
+    private static float CalculateDurationSeconds(int doorLevel)
+    {
+        var cfg = SkillsExtendedPlugin.SkillData.LockPicking;
+        
+        float baseTime = cfg.BaseLockpickDurationSeconds <= 0f ? 5f : cfg.BaseLockpickDurationSeconds;
+        float doorTimeMult = Mathf.Clamp(1f + (doorLevel - 1) * 0.25f, 1f, 2f);
+        
+        float timeReduction = 0f;
+        
+        var sm = GameUtils.GetSkillManager();
+        if (sm?.SkillManagerExtended != null)
+        {
+            timeReduction = sm.SkillManagerExtended.LockPickingTimeBuff.Value;
+        }
+        
+        float timeMultFromSkill = Mathf.Clamp(timeReduction, 0f, 0.75f);
+
+        float duration = baseTime * doorTimeMult * (1f - timeMultFromSkill);
+        return Mathf.Max(duration, 0.5f);
+    }
+
+    private static float CalculateFailChance(int doorLevel)
+    {
+        var cfg = SkillsExtendedPlugin.SkillData.LockPicking;
+        
+        float baseFail = Mathf.Clamp01(cfg.BaseFailureChance <= 0f ? 0.25f : cfg.BaseFailureChance);
+        
+        float doorFailMult = Mathf.Clamp(1f + (doorLevel - 1) * 0.2f, 1f, 1.8f);
+
+        float failReduction = 0f;
+        var sm = GameUtils.GetSkillManager();
+        if (sm?.SkillManagerExtended != null)
+        {
+            failReduction = sm.SkillManagerExtended.LockPickingForgiveness.Value;
+        }
+        
+        float failChance = baseFail * doorFailMult * (1f - failReduction);
+        
+        return Mathf.Clamp(failChance, 0f, 1f);
+    }
+    
+    private bool ShouldClose()
+    {
+        return Input.GetMouseButtonDown(0) 
+               || Input.GetMouseButtonDown(1) 
+               || Input.GetKey(KeyCode.Escape); 
+    }
+}

--- a/Plugin/Skills/LockPicking/Alternative/AlternativeLockpickUI.cs
+++ b/Plugin/Skills/LockPicking/Alternative/AlternativeLockpickUI.cs
@@ -1,0 +1,388 @@
+﻿using System.Collections;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace SkillsExtended.Skills.LockPicking.Alternative;
+
+public class AlternativeLockpickUI : MonoBehaviour
+{
+    private static AlternativeLockpickUI _instance;
+    
+    private GameObject _ringRootGo;
+    private CanvasGroup _group;
+    private Canvas _canvas;
+    private Image _fill;
+    private TextMeshProUGUI _secondsText;
+    private TextMeshProUGUI _labelText;
+    
+    private Coroutine _blinkRoutine;
+    private Coroutine _resultRoutine;
+    
+    private const float RootSizePx = 64f;
+    private const float RingThicknessPx = 4f;
+    private const float FillInsetPx = 0f;
+    
+    private static readonly Color32 ColorProgress = new Color32(0xB5, 0xC1, 0xAD, 0xFF);
+    private static readonly Color32 ColorText = new Color32(0xDA, 0xDA, 0xBC, 0xFF);
+    private static readonly Color32 ColorSuccess = new Color32(0x9A, 0xD3, 0x23, 0xFF);
+    private static readonly Color32 ColorFailure = new Color32(0xEC, 0x4D, 0x31, 0xFF);
+    
+    public static AlternativeLockpickUI EnsureInstance()
+    {
+        if (_instance != null)
+        {
+            return _instance;
+        }
+
+        var go = new GameObject("SkillsExtended.AltLockpickUi");
+        DontDestroyOnLoad(go);
+        _instance = go.AddComponent<AlternativeLockpickUI>();
+        _instance.Build();
+        _instance.Hide();
+        return _instance;
+    }
+
+    private void Build()
+    {
+        _group = gameObject.AddComponent<CanvasGroup>();
+        _group.alpha = 1f;
+        
+        _canvas = gameObject.AddComponent<Canvas>();
+        _canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        _canvas.sortingOrder = 5000;
+        
+        var scaler = gameObject.AddComponent<CanvasScaler>();
+        scaler.uiScaleMode = CanvasScaler.ScaleMode.ConstantPixelSize;
+        scaler.scaleFactor = 1f;
+
+        gameObject.AddComponent<GraphicRaycaster>();
+        
+        const int spriteSize = 256;
+        
+        float thicknessInSpritePx = (RingThicknessPx / RootSizePx) * spriteSize;
+
+        var ringSprite = MakeRingSprite(size: spriteSize, thickness: thicknessInSpritePx, feather: 2.0f);
+        
+        var root = new GameObject("Root", typeof(RectTransform));
+        root.transform.SetParent(_canvas.transform, false);
+
+        var rootRt = root.GetComponent<RectTransform>();
+        rootRt.anchorMin = new Vector2(0.5f, 0.16f);
+        rootRt.anchorMax = new Vector2(0.5f, 0.16f);
+        rootRt.pivot = new Vector2(0.5f, 0.5f);
+        rootRt.sizeDelta = new Vector2(RootSizePx, RootSizePx + 26f);
+        
+        _ringRootGo = new GameObject("RingRoot", typeof(RectTransform));
+        _ringRootGo.transform.SetParent(root.transform, false);
+
+        var ringRt = _ringRootGo.GetComponent<RectTransform>();
+        ringRt.anchorMin = new Vector2(0.5f, 1f);
+        ringRt.anchorMax = new Vector2(0.5f, 1f);
+        ringRt.pivot = new Vector2(0.5f, 1f);
+        ringRt.anchoredPosition = Vector2.zero;
+        ringRt.sizeDelta = new Vector2(RootSizePx, RootSizePx);
+        
+        var bgGo = new GameObject("Bg", typeof(RectTransform), typeof(Image));
+        bgGo.transform.SetParent(_ringRootGo.transform, false);
+
+        var bgRt = bgGo.GetComponent<RectTransform>();
+        bgRt.anchorMin = Vector2.zero;
+        bgRt.anchorMax = Vector2.one;
+        bgRt.offsetMin = Vector2.zero;
+        bgRt.offsetMax = Vector2.zero;
+
+        var bgImg = bgGo.GetComponent<Image>();
+        bgImg.sprite = ringSprite;
+        bgImg.type = Image.Type.Simple;
+        bgImg.raycastTarget = false;
+        bgImg.color = new Color(1f, 1f, 1f, 0.15f);
+        
+        var fillGo = new GameObject("Fill", typeof(RectTransform), typeof(Image));
+        fillGo.transform.SetParent(_ringRootGo.transform, false);
+
+        var fillRt = fillGo.GetComponent<RectTransform>();
+        fillRt.anchorMin = Vector2.zero;
+        fillRt.anchorMax = Vector2.one;
+        fillRt.offsetMin = new Vector2(FillInsetPx, FillInsetPx);
+        fillRt.offsetMax = new Vector2(-FillInsetPx, -FillInsetPx);
+
+        _fill = fillGo.GetComponent<Image>();
+        _fill.sprite = ringSprite;
+        _fill.type = Image.Type.Filled;
+        _fill.fillMethod = Image.FillMethod.Radial360;
+        _fill.fillOrigin = (int)Image.Origin360.Top;
+        _fill.fillClockwise = true;
+        _fill.fillAmount = 0f;
+        _fill.raycastTarget = false;
+        _fill.color = ColorProgress;
+
+        var font = TryGetDefaultTmpFont();
+        
+        var secondsGo = new GameObject("Seconds", typeof(RectTransform), typeof(TextMeshProUGUI));
+        secondsGo.transform.SetParent(_ringRootGo.transform, false);
+
+        var secondsRt = secondsGo.GetComponent<RectTransform>();
+        secondsRt.anchorMin = new Vector2(0.5f, 0.5f);
+        secondsRt.anchorMax = new Vector2(0.5f, 0.5f);
+        secondsRt.pivot = new Vector2(0.5f, 0.5f);
+        secondsRt.sizeDelta = new Vector2(RootSizePx, RootSizePx);
+        secondsRt.anchoredPosition = Vector2.zero;
+
+        _secondsText = secondsGo.GetComponent<TextMeshProUGUI>();
+        _secondsText.font = font;
+        _secondsText.fontSize = 16;
+        _secondsText.alignment = TextAlignmentOptions.Center;
+        _secondsText.color = ColorText;
+        _secondsText.raycastTarget = false;
+        _secondsText.enableWordWrapping = false;
+        _secondsText.text = "";
+        
+        var labelGo = new GameObject("Label", typeof(RectTransform), typeof(TextMeshProUGUI));
+        labelGo.transform.SetParent(root.transform, false);
+
+        var labelRt = labelGo.GetComponent<RectTransform>();
+        labelRt.anchorMin = new Vector2(0.5f, 0f);
+        labelRt.anchorMax = new Vector2(0.5f, 0f);
+        labelRt.pivot = new Vector2(0.5f, 0f);
+        labelRt.anchoredPosition = new Vector2(0f, -4f);
+        labelRt.sizeDelta = new Vector2(220f, 22f);
+
+        _labelText = labelGo.GetComponent<TextMeshProUGUI>();
+        _labelText.font = font;
+        _labelText.fontSize = 16;
+        _labelText.alignment = TextAlignmentOptions.Center;
+        _labelText.color = new Color(218f/255f, 218f/255f, 188f/255f, 1f);
+        _labelText.raycastTarget = false;
+        _labelText.enableWordWrapping = false;
+        _labelText.text = "";
+    }
+
+    public void Show(float initialSeconds)
+    {
+        if (_ringRootGo != null)
+        {
+            _ringRootGo.SetActive(true);
+        }
+
+        if (_secondsText != null)
+        {
+            _secondsText.enabled = true;
+        }
+
+        if (_canvas == null)
+        {
+            return;
+        }
+
+        _fill.fillAmount = 0f;
+        
+        SetSeconds(initialSeconds);
+        
+        _canvas.enabled = true;
+
+        if (_resultRoutine != null)
+        {
+            StopCoroutine(_resultRoutine); 
+            _resultRoutine = null;
+        }
+        
+        _group.alpha = 1f;
+
+        _labelText.text = "LOCKPICKING";
+        _labelText.color = ColorText;
+        
+        StartBlink();
+    }
+
+    public void SetProgress(float p)
+    {
+        if (_fill != null)
+        {
+            _fill.fillAmount = Mathf.Clamp01(p);
+        }
+    }
+
+    public void SetSeconds(float seconds)
+    {
+        if (_secondsText == null)
+        {
+            return;
+        }
+
+        if (seconds < 0f) seconds = 0f;
+        
+        _secondsText.text = $"{seconds:0.0}s";
+    }
+
+    public void Hide()
+    {
+        StopBlink();
+        
+        if (_resultRoutine != null)
+        {
+            StopCoroutine(_resultRoutine); 
+            _resultRoutine = null;
+        }
+
+        if (_group != null)
+        {
+            _group.alpha = 1f;
+        }
+        
+        _canvas.enabled = false;
+    }
+
+    private void StartBlink()
+    {
+        StopBlink();
+        _blinkRoutine = StartCoroutine(BlinkRoutine());
+    }
+
+    private void StopBlink()
+    {
+        if (_blinkRoutine != null)
+        {
+            StopCoroutine(_blinkRoutine);
+            _blinkRoutine = null;
+        }
+
+        if (_labelText != null)
+        {
+            var c = _labelText.color;
+            c.a = 0.75f;
+            _labelText.color = c;
+        }
+    }
+
+    private IEnumerator BlinkRoutine()
+    {
+        while (true)
+        {
+            float t = Mathf.PingPong(Time.unscaledTime * 2.0f, 1f);
+            float a = Mathf.Lerp(0.25f, 0.85f, t);
+
+            if (_labelText != null)
+            {
+                var c = _labelText.color;
+                c.a = a;
+                _labelText.color = c;
+            }
+
+            yield return null;
+        }
+    }
+    
+    private static Sprite MakeRingSprite(int size, float thickness, float feather)
+    {
+        var tex = new Texture2D(size, size, TextureFormat.ARGB32, false)
+        {
+            filterMode = FilterMode.Bilinear,
+            wrapMode = TextureWrapMode.Clamp
+        };
+
+        float cx = (size - 1) * 0.5f;
+        float cy = (size - 1) * 0.5f;
+
+        float outerR = Mathf.Min(cx, cy) - 1f;
+        float innerR = Mathf.Max(outerR - thickness, 0f);
+
+        var pixels = new Color32[size * size];
+
+        for (int y = 0; y < size; y++)
+        {
+            float dy = y - cy;
+            for (int x = 0; x < size; x++)
+            {
+                float dx = x - cx;
+                float dist = Mathf.Sqrt(dx * dx + dy * dy);
+                
+                float aOuter = SmoothStep(outerR + feather, outerR - feather, dist);
+                float aInner = SmoothStep(innerR - feather, innerR + feather, dist);
+                float a = Mathf.Clamp01(aOuter * aInner);
+
+                byte ab = (byte)Mathf.RoundToInt(255f * a);
+                pixels[y * size + x] = new Color32(255, 255, 255, ab);
+            }
+        }
+
+        tex.SetPixels32(pixels);
+        tex.Apply(false, true);
+
+        return Sprite.Create(tex, new Rect(0, 0, size, size), new Vector2(0.5f, 0.5f), 100f);
+    }
+
+    private static float SmoothStep(float edge0, float edge1, float x)
+    {
+        float t = Mathf.InverseLerp(edge0, edge1, x);
+        return Mathf.Clamp01(t);
+    }
+    
+    public void ShowResult(bool success)
+    {
+        StopBlink();
+
+        if (_resultRoutine != null)
+        {
+            StopCoroutine(_resultRoutine);
+            _resultRoutine = null;
+        }
+
+        if (_ringRootGo != null)
+        {
+            _ringRootGo.SetActive(false);
+        }
+        
+        if (_secondsText != null)
+        {
+            _secondsText.text = "";
+            _secondsText.enabled = false;
+        }
+
+        if (_labelText != null)
+        {
+            _labelText.text = success ? "SUCCESS" : "FAILURE";
+            _labelText.color = success ? ColorSuccess : ColorFailure;
+
+            var c = _labelText.color;
+            c.a = 1f;
+            _labelText.color = c;
+        }
+
+        _resultRoutine = StartCoroutine(ResultRoutine());
+    }
+
+    private IEnumerator ResultRoutine()
+    {
+        float hold = 1.0f;
+        while (hold > 0f)
+        {
+            hold -= Time.unscaledDeltaTime;
+            yield return null;
+        }
+        
+        float fade = 0.45f;
+        float t = 0f;
+        while (t < fade)
+        {
+            t += Time.unscaledDeltaTime;
+            float a = Mathf.Lerp(1f, 0f, Mathf.Clamp01(t / fade));
+            if (_group != null) _group.alpha = a;
+            yield return null;
+        }
+
+        Hide();
+    }
+    
+    private static TMP_FontAsset TryGetDefaultTmpFont()
+    {
+        try
+        {
+            return TMP_Settings.defaultFontAsset;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/Server/Resources/Configs/SkillsConfig.json
+++ b/Server/Resources/Configs/SkillsConfig.json
@@ -207,6 +207,9 @@
     },
     "LockPicking": {
         "Enabled": true,
+        "UseAlternativeLockpicking": false,
+        "BaseLockpickDurationSeconds": 5,
+        "BaseFailureChance": 0.25,
         "PickStrengthBase": 1.50,
         "PickStrengthPerLevel": 2.5,
         "SweetSpotRangeBase": 3.75,

--- a/Server/Web/Pages/SkillConfigs/Lockpicking.razor
+++ b/Server/Web/Pages/SkillConfigs/Lockpicking.razor
@@ -6,7 +6,7 @@
 
 <MudGrid Justify="Justify.Center" Style="min-height:100vh; display:flex; align-items:center;">
     <MudItem xs="11" sm="8" md="6" lg="4">
-        <MudPaper Height="400px" Style="width:100%;">
+        <MudPaper Class="pa-6" Style="width:100%;">
             <MudContainer MaxWidth="MaxWidth.Medium">
                 <MudGrid>
                     <MudItem xs="6">
@@ -16,42 +16,73 @@
                             Label="Enabled"
                             Color="Color.Success"/>
                     </MudItem>
-
+                    
                     <MudItem xs="6">
-                        <MudNumericField
-                            @bind-Value="PickStrength"
-                            Label="Base Pick Strength"
-                            Variant="Variant.Filled"
-                            Step=".05M"
-                            Min="0" Max="25"/>
+                        <MudSwitch
+                            Class="d-flex align-center justify-center mud-width-full py-8"
+                            @bind-Value="MinigameLockpicking"
+                            Label="Minigame"
+                            Color="Color.Success" />
                     </MudItem>
 
-                    <MudItem xs="6">
-                        <MudNumericField
-                            @bind-Value="PerStrengthBonusPerLevel"
-                            Label="Pick Strength Bonus Per Level"
-                            Variant="Variant.Filled"
-                            Step=".05M"
-                            Min="0" Max="1"/>
-                    </MudItem>
+                    @if (MinigameLockpicking)
+                    {
+                        <MudItem xs="6">
+                            <MudNumericField
+                                @bind-Value="PickStrength"
+                                Label="Base Pick Strength"
+                                Variant="Variant.Filled"
+                                Step=".05M"
+                                Min="0" Max="25"/>
+                        </MudItem>
 
-                    <MudItem xs="6">
-                        <MudNumericField
-                            @bind-Value="SweetSpotRange"
-                            Label="Base Sweet Spot Range"
-                            Variant="Variant.Filled"
-                            Step=".05M"
-                            Min="0" Max="1"/>
-                    </MudItem>
+                        <MudItem xs="6">
+                            <MudNumericField
+                                @bind-Value="PerStrengthBonusPerLevel"
+                                Label="Pick Strength Bonus Per Level"
+                                Variant="Variant.Filled"
+                                Step=".05M"
+                                Min="0" Max="1"/>
+                        </MudItem>
 
-                    <MudItem xs="6">
-                        <MudNumericField
-                            @bind-Value="SweetSpotRangePerLevel"
-                            Label="Sweet Spot Range Per Level"
-                            Variant="Variant.Filled"
-                            Step=".05M"
-                            Min="0" Max="1"/>
-                    </MudItem>
+                        <MudItem xs="6">
+                            <MudNumericField
+                                @bind-Value="SweetSpotRange"
+                                Label="Base Sweet Spot Range"
+                                Variant="Variant.Filled"
+                                Step=".05M"
+                                Min="0" Max="1"/>
+                        </MudItem>
+
+                        <MudItem xs="6">
+                            <MudNumericField
+                                @bind-Value="SweetSpotRangePerLevel"
+                                Label="Sweet Spot Range Per Level"
+                                Variant="Variant.Filled"
+                                Step=".05M"
+                                Min="0" Max="1"/>
+                        </MudItem>
+                    }
+                    else
+                    {
+                        <MudItem xs="6">
+                            <MudNumericField
+                                @bind-Value="BaseLockpickDurationSeconds"
+                                Label="Base lockpicking time (sec)"
+                                Variant="Variant.Filled"
+                                Step=".1M"
+                                Min="0.1M" Max="60" />
+                        </MudItem>
+
+                        <MudItem xs="6">
+                            <MudNumericField
+                                @bind-Value="BaseFailureChance"
+                                Label="Base failure chance"
+                                Variant="Variant.Filled"
+                                Step=".01M"
+                                Min="0" Max="1" />
+                        </MudItem>
+                    }
                     
                     <MudItem xs="6">
                         <MudNumericField
@@ -93,6 +124,24 @@
     {
         get => Data.Enabled;
         set => Data.Enabled = value;
+    }
+    
+    bool MinigameLockpicking
+    {
+        get => !Data.UseAlternativeLockpicking;
+        set => Data.UseAlternativeLockpicking = !value;
+    }
+    
+    decimal BaseLockpickDurationSeconds
+    {
+        get => (decimal)Data.BaseLockpickDurationSeconds;
+        set => Data.BaseLockpickDurationSeconds = (float)value;
+    }
+
+    decimal BaseFailureChance
+    {
+        get => (decimal)Data.BaseFailureChance;
+        set => Data.BaseFailureChance = (float)value;
     }
     
     decimal PickStrength


### PR DESCRIPTION
Alternative lockpicking mode that disables the minigame.

- Added a custom UI to visually display the lockpicking process, reusing lockpicking sounds from the existing bundle.
- Added a config toggle plus two main parameters:
  - Base lockpick duration (default: 5 seconds)
  - Base failure chance (default: 25%)

Door-level scaling formulas:
- Lockpick duration = BaseDuration * (1 + 0.25 * (DoorLevel - 1)) * (1 - LockPickingTimeBuff)
- Failure chance = BaseFailChance * (1 + 0.20 * (DoorLevel - 1)) * (1 - LockPickingForgiveness)