### PR TITLE
Update packet work with Fika 2.2,4+

### DIFF
--- a/FikaSync/Packets/LockPickingSyncPacket.cs
+++ b/FikaSync/Packets/LockPickingSyncPacket.cs
@@ -20,7 +20,7 @@ public struct LockPickingSyncPacket : INetSerializable
     
     public void Serialize(NetDataWriter writer)
     {
-        writer.Put(DoorId);
+        writer.Put(DoorId,128);
         writer.Put(Attempts);
         writer.Put(Unlocked);
         writer.Put(Broken);


### PR DESCRIPTION
Update packet to include max length for DoorId string to work with Fika 2.2.4+. Did a quick look and there aren't any door ids with a length over 64 bytes, so 128 should be fine.